### PR TITLE
Updates to ASpace core overrides & custom exports

### DIFF
--- a/backend/lib/ead_user_defined_field_serialize.rb
+++ b/backend/lib/ead_user_defined_field_serialize.rb
@@ -8,6 +8,9 @@ class EADUserDefinedFieldSerialize
         xml.physloc('label' => 'Location', 'audience' => 'internal') {
           xml.text data.user_defined['enum_1'].gsub(/^.* - /, '')
         }
+         xml.physloc('label' => 'Location', 'audience' => 'external') {
+          xml.text I18n.t({:enumeration => 'user_defined_enum_1', :value => data.user_defined['enum_1']}, :default => data.user_defined['enum_1']).gsub(/ - .*/, '')
+        }
       end
     elsif context == :archdesc
       # FIXME: Contribute this to the core code?

--- a/backend/lib/marc_user_defined_field_serialize.rb
+++ b/backend/lib/marc_user_defined_field_serialize.rb
@@ -35,22 +35,37 @@ class MARCUserDefinedFieldSerialize
 
   def datafields
     extra_fields = []
+    
+    if @record.aspace_record.ead_id
+      extra_fields << DataField.new('035', ' ', ' ', [SubField.new('a', @record.aspace_record.ead_id)])
+    end
+    
+    if @record.aspace_record.id_0
+      prefer_cite = "Rauner " + @record.aspace_record.id_0 + "; Rauner Special Collections Library, Dartmouth College, Hanover, NH."
+      extra_fields << DataField.new('524', ' ', ' ', [SubField.new('a', prefer_cite)])
+    end
+    
+    
     if @record.aspace_record.user_defined
 
       user_defined = @record.aspace_record.user_defined
 
-
-      if user_defined['enum_1']
+      if user_defined['enum_1'] && @record.aspace_record.id_0
         location_code = user_defined['enum_1'].gsub(/^.* - /, '')
-        extra_fields << DataField.new('950', '0', '4', [SubField.new('l', location_code)])
+        extra_fields << DataField.new('950', '0', '4', [SubField.new('b', @record.aspace_record.id_0),SubField.new('l', location_code)])
       end
 
       if user_defined['text_1']
         extra_fields << DataField.new('580', ' ', ' ', [SubField.new('a', user_defined['text_1'])])
+        extra_fields << DataField.new('710', '2', ' ', [SubField.new('a', user_defined['text_1'])])
       end
 
       if user_defined['text_2']
         extra_fields << DataField.new('830', ' ', '0', [SubField.new('p', user_defined['text_2'])])
+      end
+      
+      if user_defined['text_5']
+        extra_fields << DataField.new('518', ' ', ' ', [SubField.new('a', user_defined['text_5'])])
       end
 
     end


### PR DESCRIPTION
Core patches:
Override ASpace Creator Dates to use preferred Dates of Existence.
Override MARC 555 & 856 subfield a language.

Custom fields:
Add additional EAD physloc tag. Enumerations are still not working here.
Add/update MARC 035, 518, 524, 710, 950 custom fields
